### PR TITLE
🩹バナナケーキのスキーマ読み込めないの修正

### DIFF
--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -10,7 +10,7 @@
         }
         
         // 仮置き
-        private class Query
+        public class Query
         {
             public string Hello() => "Hello, GraphQL!";
         }


### PR DESCRIPTION
仮置きクエリクラスのアクセス修飾子をpublicにした