### PR TITLE
🐛 JWT認証の環境変数読み込み不具合を修正

### DIFF
--- a/EcSiteBackend/docker-compose.yml
+++ b/EcSiteBackend/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - ASPNETCORE_URLS=http://+:8080
       - JWTSettings__Secret=${JWTSettings__Secret}
       - JWTSettings__ExpirationInMinutes=${JWTSettings__ExpirationInMinutes}
+      - JWTSettings__Issuer=${JWTSettings__Issuer}
+      - JWTSettings__Audience=${JWTSettings__Audience}
       - ConnectionStrings__DefaultConnection=${ConnectionStrings__DefaultConnection}
     depends_on:
       - db

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -34,9 +34,19 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
             var connectionString = _configuration.GetConnectionString("DefaultConnection");
 
             // JWT設定を読み込み
-            var jwtSettings = new JwtSettings();
-            _configuration.GetSection("JwtSettings").Bind(jwtSettings);
-            services.Configure<JwtSettings>(_configuration.GetSection("JwtSettings"));
+            var jwtSecret = _configuration["JwtSettings:Secret"];
+            var jwtIssuer = _configuration["JwtSettings:Issuer"];
+            var jwtAudience = _configuration["JwtSettings:Audience"];
+            var jwtExpiration = _configuration["JwtSettings:ExpirationInMinutes"];
+
+            // JWT設定をDIコンテナに登録
+            services.Configure<JwtSettings>(options =>
+            {
+                options.Secret = jwtSecret ?? throw new ArgumentNullException("JWT Secret is not configured.");
+                options.Issuer = jwtIssuer ?? throw new ArgumentNullException("JWT Issuer is not configured.");
+                options.Audience = jwtAudience ?? throw new ArgumentNullException("JWT Audience is not configured.");
+                options.ExpirationInMinutes = int.Parse(jwtExpiration ?? "60");
+            });
 
             // JWT認証の設定
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -48,13 +58,14 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
                         ValidateAudience = true,
                         ValidateLifetime = true,
                         ValidateIssuerSigningKey = true,
-                        ValidIssuer = jwtSettings.Issuer,
-                        ValidAudience = jwtSettings.Audience,
+                        ValidIssuer = jwtIssuer,
+                        ValidAudience = jwtAudience,
                         IssuerSigningKey = new SymmetricSecurityKey(
-                            Encoding.UTF8.GetBytes(jwtSettings.Secret))
+                            Encoding.UTF8.GetBytes(jwtSecret))
                     };
                 });
 
+            
             // 1. DbContext
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseNpgsql(connectionString));

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -61,7 +61,7 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
                         ValidIssuer = jwtIssuer,
                         ValidAudience = jwtAudience,
                         IssuerSigningKey = new SymmetricSecurityKey(
-                            Encoding.UTF8.GetBytes(jwtSecret))
+                            Encoding.UTF8.GetBytes(jwtSecret!))
                     };
                 });
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ JWTSettings__Secret="your-64-character-safe-jwt-secret-key-here-xxxxxxxxxxxxxxxx
 # JWT トークンの有効期限（分単位）
 JWTSettings__ExpirationInMinutes=60
 
-# JWT Issuer (発行者)v
+# JWT Issuer (発行者)
 JWTSettings__Issuer="EcSiteBackend"
 
 # JWT Audience (対象利用者)


### PR DESCRIPTION
 ## PR: JWT認証の環境変数読み込み不具合を修正

### 概要
Docker環境でJWT認証が機能しない問題を修正した。環境変数から`JwtSettings`の`Issuer`と`Audience`が正しく読み込まれず、トークン検証時に`IDX10206: Unable to validate audience`エラーが発生していた。

### 問題の詳細
- 環境変数`JWTSettings__Issuer`と`JWTSettings__Audience`は正しく設定されていたが、アプリケーション側で読み込めていなかった
- `IConfiguration.GetSection().Bind()`メソッドによる設定のバインディングが環境変数に対して正常に動作していなかった
- 結果として、JWT検証時にAudienceがnullまたは空となり、認証が失敗していた

### 変更内容

1. Startup.csでJWT設定の読み込み方法を修正
2. 環境変数から直接設定値を取得する方式に変更
3. JWT認証設定で直接値を使用
