### PR TITLE
✅UpdateUserInteractorの単体テストを追加

### DIFF
--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorCodes.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorCodes.cs
@@ -12,6 +12,7 @@ namespace EcSiteBackend.Application.Common.Constants
         public const string Unauthorized = "UNAUTHORIZED";
         public const string Forbidden = "FORBIDDEN";
         public const string InternalError = "INTERNAL_ERROR";
+        public const string InvalidArguments = "INVALID_ARGUMENTS";
 
         // ユーザー関連
         public const string UserNotFound = "USER_NOT_FOUND";

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorMassage.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorMassage.cs
@@ -9,7 +9,7 @@ namespace EcSiteBackend.Application.Common.Constants
         public const string ValidationError = "入力内容に誤りがあります。";
         public const string NotFound = "{0} (ID: {1}) が見つかりません。";
         public const string InternalError = "システムエラーが発生しました。";
-
+        public const string InvalidArguments = "無効な引数が指定されたか、必須の引数が不足しています。";
         // ユーザー関連
         public const string EmailAlreadyExists = "このメールアドレスは既に使用されています。";
         public const string InvalidCredentials = "メールアドレスまたはパスワードが正しくありません。";

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Exceptions/InvalidAugmentsException.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Exceptions/InvalidAugmentsException.cs
@@ -1,0 +1,21 @@
+using EcSiteBackend.Application.Common.Constants;
+
+namespace EcSiteBackend.Application.Common.Exceptions
+{
+    /// <summary>
+    /// 権限エラー
+    /// </summary>
+    public class InvalidArgumentsException : ApplicationException
+    {
+        public InvalidArgumentsException(string message)
+            : base(ErrorCodes.InvalidArguments, message)
+        {
+        }
+    
+        // エンティティ名とIDを指定するオーバーロード
+        public InvalidArgumentsException(string entityName, object key)
+            : base(ErrorCodes.InvalidArguments, $"{entityName} に無効な引数が指定されました。Value: {key}")
+        {
+        }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/UpdateUserInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/UpdateUserInteractor.cs
@@ -43,6 +43,12 @@ namespace EcSiteBackend.Application.UseCases.Interactors
         /// </summary>
         public async Task<UserDto> ExecuteAsync(UpdateUserInput input, CancellationToken cancellationToken)
         {
+            // input内のIDが空の場合は例外をスロー
+            if (input.Id == Guid.Empty)
+            {
+                throw new InvalidArgumentsException("User ID", input.Id);
+            }
+
             var user = new User();
 
             await _transactionService.ExecuteAsync(async () =>

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignInInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignInInteractorTests.cs
@@ -11,7 +11,7 @@ using EcSiteBackend.Application.Common.Constants;
 using Microsoft.Extensions.Options;
 using EcSiteBackend.Application.Common.Settings;
 
-namespace EcSiteBackend.Interactors.UnitTests
+namespace EcSiteBackend.UnitTests.Interactors
 {
     /// <summary>
     /// ユーザー認証（サインイン）ユースケースのテストクラス

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignInInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignInInteractorTests.cs
@@ -55,7 +55,6 @@ namespace EcSiteBackend.UnitTests.Interactors
         }
 
         [Fact(DisplayName ="正常系: 入力が有効な場合、ログイン履歴が作成され、トークンが帰る")]
-
         public async Task SignIn_ShouldCreateLoginHistoryAndReturnToken_WhenInputIsValid()
         {
             // Arrange

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignUpInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignUpInteractorTests.cs
@@ -11,7 +11,7 @@ using EcSiteBackend.Application.Common.Constants;
 using Microsoft.Extensions.Options;
 using EcSiteBackend.Application.Common.Settings;
 
-namespace EcSiteBackend.Interactors.UnitTests
+namespace EcSiteBackend.UnitTests.Interactors
 {
     /// <summary>
     /// ユーザー登録（サインアップ）ユースケースのテストクラス

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -1,0 +1,45 @@
+using EcSiteBackend.Application.UseCases.Interactors;
+using EcSiteBackend.Application.Common.Interfaces.Repositories;
+using EcSiteBackend.Application.Common.Interfaces;
+using AutoMapper;
+using Moq;
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+using EcSiteBackend.Domain.Entities;
+using EcSiteBackend.Application.DTOs;
+using EcSiteBackend.Application.Common.Exceptions;
+using EcSiteBackend.Application.Common.Constants;
+using EcSiteBackend.Application.Common.Interfaces.Services;
+using Microsoft.Extensions.Options;
+using EcSiteBackend.Application.Common.Settings;
+
+namespace EcSiteBackend.UnitTests.Interactors
+{
+    /// <summary>
+    /// ユーザー情報更新ユースケースのテストクラス
+    /// </summary>
+    public class UpdateUserInteractorTests
+    {
+        private readonly Mock<IGenericRepository<User>> _userRepositoryMock;
+        private readonly Mock<IHistoryService> _historyServiceMock;
+        private readonly Mock<ITransactionService> _transactionServiceMock;
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly UpdateUserInteractor _interactor;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public UpdateUserInteractorTests()
+        {
+            _userRepositoryMock = new Mock<IGenericRepository<User>>();
+            _historyServiceMock = new Mock<IHistoryService>();
+            _transactionServiceMock = new Mock<ITransactionService>();
+            _mapperMock = new Mock<IMapper>();
+
+            _interactor = new UpdateUserInteractor(
+                _userRepositoryMock.Object,
+                _historyServiceMock.Object,
+                _transactionServiceMock.Object,
+                _mapperMock.Object);
+        }
+    }
+}

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -211,7 +211,25 @@ namespace EcSiteBackend.UnitTests.Interactors
         [Fact(DisplayName = "異常系:ユーザーIDがGuid.Emptyの場合、NotFoundExceptionがスローされること")]
         public async Task UpdateUser_EmptyGuid_ShouldThrowNotFoundException()
         {
-            // TODO: 実装
+            // Arrange
+            var userId = Guid.Empty;
+            var input = new UpdateUserInput
+            {
+                Id = userId,
+                FirstName = "UpdateFirstName"
+            };
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<NotFoundException>(
+                () => _interactor.ExecuteAsync(input, CancellationToken.None));
+
+            Assert.Contains($"User (ID: {userId}) が見つかりません。", exception.Message);
+
+            // リポジトリが呼ばれたことを確認
+            _userRepositoryMock.Verify(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+            // 更新系のメソッドは呼ばれないことを確認
+            _userRepositoryMock.Verify(repo => repo.Update(It.IsAny<User>()), Times.Never);
+            _userRepositoryMock.Verify(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact(DisplayName = "異常系:リポジトリでエラーが発生した場合、トランザクションがロールバックされること")]

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -220,14 +220,13 @@ namespace EcSiteBackend.UnitTests.Interactors
             };
 
             // Act & Assert
-            var exception = await Assert.ThrowsAsync<NotFoundException>(
+            var exception = await Assert.ThrowsAsync<InvalidArgumentsException>(
                 () => _interactor.ExecuteAsync(input, CancellationToken.None));
 
-            Assert.Contains($"User (ID: {userId}) が見つかりません。", exception.Message);
+            Assert.Contains("無効な引数が指定されました", exception.Message);
 
-            // リポジトリが呼ばれたことを確認
-            _userRepositoryMock.Verify(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
-            // 更新系のメソッドは呼ばれないことを確認
+            // 依存関係は呼ばれないことを確認
+            _userRepositoryMock.Verify(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Never);
             _userRepositoryMock.Verify(repo => repo.Update(It.IsAny<User>()), Times.Never);
             _userRepositoryMock.Verify(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
         }

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -43,7 +43,7 @@ namespace EcSiteBackend.UnitTests.Interactors
                 _mapperMock.Object);
         }
 
-        [Fact(DisplayName = "ユーザー情報（FirstName）のみ更新できること")]
+        [Fact(DisplayName = "正常系:ユーザー情報（FirstName）のみ更新できること")]
         public async Task UpdateUser_FirstNameOnly_ShouldUpdateSuccessfully()
         {
             // Arrange
@@ -131,7 +131,49 @@ namespace EcSiteBackend.UnitTests.Interactors
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
 
-        [Fact(DisplayName = "存在しないユーザーIDの場合、NotFoundExceptionがスローされること")]
+        [Fact(DisplayName = "正常系:ユーザー情報（LastName）のみ更新できること")]
+        public async Task UpdateUser_LastNameOnly_ShouldUpdateSuccessfully()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "正常系:ユーザー情報（PhoneNumber）のみ更新できること")]
+        public async Task UpdateUser_PhoneNumberOnly_ShouldUpdateSuccessfully()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "正常系:複数フィールドを同時に更新できること")]
+        public async Task UpdateUser_MultipleFields_ShouldUpdateSuccessfully()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "正常系:空文字列/nullの場合は既存値が保持されること")]
+        public async Task UpdateUser_EmptyOrNullInput_ShouldKeepExistingValues()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "正常系:更新履歴が正しく作成されること")]
+        public async Task UpdateUser_ShouldCreateHistory()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "正常系:監査情報（UpdatedAt/UpdatedBy）が設定されること")]
+        public async Task UpdateUser_ShouldSetAuditFields()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "正常系:トランザクション内で処理が実行されること")]
+        public async Task UpdateUser_ShouldExecuteWithinTransaction()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "異常系:存在しないユーザーIDの場合、NotFoundExceptionがスローされること")]
         public async Task UpdateUser_UserNotFound_ShouldThrowNotFoundException()
         {
             // Arrange
@@ -164,6 +206,24 @@ namespace EcSiteBackend.UnitTests.Interactors
             // 更新系のメソッドは呼ばれないことを確認
             _userRepositoryMock.Verify(repo => repo.Update(It.IsAny<User>()), Times.Never);
             _userRepositoryMock.Verify(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact(DisplayName = "異常系:ユーザーIDがGuid.Emptyの場合、NotFoundExceptionがスローされること")]
+        public async Task UpdateUser_EmptyGuid_ShouldThrowNotFoundException()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "異常系:リポジトリでエラーが発生した場合、トランザクションがロールバックされること")]
+        public async Task UpdateUser_RepositoryError_ShouldRollbackTransaction()
+        {
+            // TODO: 実装
+        }
+
+        [Fact(DisplayName = "異常系:履歴サービスでエラーが発生した場合、トランザクションがロールバックされること")]
+        public async Task UpdateUser_HistoryServiceError_ShouldRollbackTransaction()
+        {
+            // TODO: 実装
         }
     }
 }

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -11,6 +11,7 @@ using EcSiteBackend.Application.Common.Constants;
 using EcSiteBackend.Application.Common.Interfaces.Services;
 using Microsoft.Extensions.Options;
 using EcSiteBackend.Application.Common.Settings;
+using EcSiteBackend.Domain.Enums;
 
 namespace EcSiteBackend.UnitTests.Interactors
 {
@@ -40,6 +41,129 @@ namespace EcSiteBackend.UnitTests.Interactors
                 _historyServiceMock.Object,
                 _transactionServiceMock.Object,
                 _mapperMock.Object);
+        }
+
+        [Fact(DisplayName = "ユーザー情報（FirstName）のみ更新できること")]
+        public async Task UpdateUser_FirstNameOnly_ShouldUpdateSuccessfully()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var input = new UpdateUserInput
+            {
+                Id = userId,
+                FirstName = "UpdatedFirstName"
+            };
+
+            // 既存のユーザー
+            var existingUser = new User
+            {
+                Id = userId,
+                FirstName = "OldFirstName",
+                LastName = "変更なし",
+                Email = "never.change@zmail.com",
+                PhoneNumber = "111-1111-1111",
+                CreatedAt = DateTime.UtcNow.AddDays(-1),
+                IsActive = true
+            };
+
+            // 期待される帰り値
+            var expectedUserDto = new UserDto
+            {
+                Id = userId,
+                FirstName = "UpdatedFirstName",
+                LastName = "変更なし",
+                Email = "never.change@zmail.com",
+                PhoneNumber = "111-1111-1111"
+            };
+
+            // モックの設定
+            _userRepositoryMock
+                .Setup(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingUser);
+
+            _userRepositoryMock
+                .Setup(repo => repo.Update(It.IsAny<User>()));
+
+            _userRepositoryMock
+                .Setup(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            _mapperMock
+                .Setup(mapper => mapper.Map<UserDto>(It.IsAny<User>()))
+                .Returns(expectedUserDto);
+
+            _historyServiceMock
+                .Setup(service => service.CreateUserHistoryAsync(
+                    It.IsAny<User>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // TransactionServiceのモックを修正
+            _transactionServiceMock
+                .Setup(t => t.ExecuteAsync(It.IsAny<Func<Task>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task>, CancellationToken>(async (action, ct) =>
+                {
+                    await action();
+                });
+
+            // Act
+            var result = await _interactor.ExecuteAsync(input, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedUserDto.Id, result.Id);
+            Assert.Equal(expectedUserDto.FirstName, result.FirstName);
+
+            // 依存関係呼び出しの検証
+            _userRepositoryMock.Verify(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+            _userRepositoryMock.Verify(repo => repo.Update(It.Is<User>(u =>
+                u.Id == userId &&
+                u.FirstName == "UpdatedFirstName" &&
+                u.LastName == "変更なし")), Times.Once);
+            _userRepositoryMock.Verify(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _historyServiceMock.Verify(service => service.CreateUserHistoryAsync(
+                It.IsAny<User>(),
+                OperationType.Update,
+                userId,
+                It.IsAny<CancellationToken>()), Times.Once);
+            _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
+        }
+
+        [Fact(DisplayName = "存在しないユーザーIDの場合、NotFoundExceptionがスローされること")]
+        public async Task UpdateUser_UserNotFound_ShouldThrowNotFoundException()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var input = new UpdateUserInput
+            {
+                Id = userId,
+                FirstName = "UpdatedFirstName"
+            };
+
+            _userRepositoryMock
+                .Setup(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((User)null!);
+
+            _transactionServiceMock
+                .Setup(t => t.ExecuteAsync(It.IsAny<Func<Task>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task>, CancellationToken>(async (action, ct) =>
+                {
+                    await action();
+                });
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<NotFoundException>(
+                () => _interactor.ExecuteAsync(input, CancellationToken.None));
+
+            Assert.Contains($"User (ID: {userId}) が見つかりません。", exception.Message);
+
+            // リポジトリが呼ばれたことを確認
+            _userRepositoryMock.Verify(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+            // 更新系のメソッドは呼ばれないことを確認
+            _userRepositoryMock.Verify(repo => repo.Update(It.IsAny<User>()), Times.Never);
+            _userRepositoryMock.Verify(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
     }
 }

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -222,7 +222,90 @@ namespace EcSiteBackend.UnitTests.Interactors
         [Fact(DisplayName = "正常系:ユーザー情報（PhoneNumber）のみ更新できること")]
         public async Task UpdateUser_PhoneNumberOnly_ShouldUpdateSuccessfully()
         {
-            // TODO: 実装
+            // Arrange
+            var userId = Guid.NewGuid();
+            var input = new UpdateUserInput
+            {
+                Id = userId,
+                PhoneNumber = "222-2222-2222"
+            };
+
+            // 既存のユーザー
+            var existingUser = new User
+            {
+                Id = userId,
+                FirstName = "変更なし",
+                LastName = "変更なし",
+                Email = "never.change@zmail.com",
+                PhoneNumber = "111-1111-1111",
+                CreatedAt = DateTime.UtcNow.AddDays(-1),
+                IsActive = true
+            };
+
+            // 期待される帰り値
+            var expectedUserDto = new UserDto
+            {
+                Id = userId,
+                FirstName = "変更なし",
+                LastName = "変更なし",
+                Email = "never.change@zmail.com",
+                PhoneNumber = "222-2222-2222"
+            };
+
+            // モックの設定
+            _userRepositoryMock
+                .Setup(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingUser);
+
+            _userRepositoryMock
+                .Setup(repo => repo.Update(It.IsAny<User>()));
+
+            _userRepositoryMock
+                .Setup(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            _mapperMock
+                .Setup(mapper => mapper.Map<UserDto>(It.IsAny<User>()))
+                .Returns(expectedUserDto);
+
+            _historyServiceMock
+                .Setup(service => service.CreateUserHistoryAsync(
+                    It.IsAny<User>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // TransactionServiceのモックを修正
+            _transactionServiceMock
+                .Setup(t => t.ExecuteAsync(It.IsAny<Func<Task>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task>, CancellationToken>(async (action, ct) =>
+                {
+                    await action();
+                });
+
+            // Act
+            var result = await _interactor.ExecuteAsync(input, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedUserDto.Id, result.Id);
+            Assert.Equal(expectedUserDto.FirstName, result.FirstName);
+
+            // 依存関係呼び出しの検証
+            _userRepositoryMock.Verify(repo => repo.GetByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+            _userRepositoryMock.Verify(repo => repo.Update(It.Is<User>(u =>
+                u.Id == userId &&
+                u.FirstName == "変更なし" &&
+                u.LastName == "変更なし" &&
+                u.PhoneNumber == "222-2222-2222")), Times.Once);
+            _userRepositoryMock.Verify(repo => repo.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _historyServiceMock.Verify(service => service.CreateUserHistoryAsync(
+                It.IsAny<User>(),
+                OperationType.Update,
+                userId,
+                It.IsAny<CancellationToken>()), Times.Once);
+            _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
 
         [Fact(DisplayName = "正常系:複数フィールドを同時に更新できること")]


### PR DESCRIPTION
テスト対象のコードにinput.Idが空の時の例外を追加、カスタム例外クラスも追加した

### テストケース

1. **正常系**
   - [x] ユーザー情報（FirstName）のみ更新できること
   - [x] ユーザー情報（LastName）のみ更新できること
   - [x] ユーザー情報（PhoneNumber）のみ更新できること
   - [x] 複数フィールドを同時に更新できること
   - [x] 空文字列/nullの場合は既存値が保持されること
   - [x] 更新履歴が正しく作成されること
   - [x] 監査情報（UpdatedAt/UpdatedBy）が設定されること
   - [x] TransactionServiceのExecuteAsyncメソッドが呼ばれること
2. **異常系**
   - [x] 存在しないユーザーIDの場合、NotFoundExceptionがスローされること
   - [x] ユーザーIDがGuid.Emptyの場合、NotFoundExceptionがスローされること
   - [x] 異常系:リポジトリのUpdate時にエラーが発生した場合、後続処理がスキップされること
   - [x] 異常系:履歴サービスでエラーが発生した場合、例外が伝播すること
