### PR TITLE
:sparkles: ログイン済みユーザーのパスワード変更機能を実装

### DIFF
--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorCodes.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorCodes.cs
@@ -34,5 +34,6 @@ namespace EcSiteBackend.Application.Common.Constants
         // パスワード
         public const string PasswordMismatch = "PASSWORD_MISMATCH";
         public const string SameAsCurrentPassword = "SAME_AS_CURRENT_PASSWORD";
+        public const string InvalidPasswordReason = "Invalid current password during password change";
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorCodes.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorCodes.cs
@@ -30,5 +30,9 @@ namespace EcSiteBackend.Application.Common.Constants
 
         // 権限
         public const string BusinessRuleViolation = "BUSINESS_RULE_VIOLATION";
+
+        // パスワード
+        public const string PasswordMismatch = "PASSWORD_MISMATCH";
+        public const string SameAsCurrentPassword = "SAME_AS_CURRENT_PASSWORD";
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorMassage.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorMassage.cs
@@ -27,5 +27,12 @@ namespace EcSiteBackend.Application.Common.Constants
         public const string InvalidToken = "認証情報が無効です。再度ログインしてください。";
         public const string TokenExpired = "認証の有効期限が切れています。再度ログインしてください。";
         public const string MissingAuthHeader = "認証情報が見つかりません。";
+
+        // パスワード
+        public const string PasswordMismatch = "新しいパスワードと確認用パスワードが一致しません。";
+        public const string SameAsCurrentPassword = "新しいパスワードは現在のパスワードと異なる必要があります。";
+        public const string PasswordTooShort = "パスワードは8文字以上である必要があります。";
+        public const string UserNotFound = "ユーザーが見つかりません。";
+        public const string WeakPassword = "パスワードは8文字以上で、大文字・小文字・数字を含む必要があります。";
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IHistoryService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IHistoryService.cs
@@ -18,6 +18,13 @@ namespace EcSiteBackend.Application.Common.Interfaces.Services
         /// <param name="operatedBy"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task CreateUserHistoryAsync(User user, OperationType operationType, Guid operatedBy, CancellationToken cancellationToken = default);
+        Task CreateUserHistoryAsync(
+            User user,
+            OperationType operationType,
+            Guid operatedBy,
+            string? ipAddress = null,
+            string? userAgent = null,
+            CancellationToken cancellationToken = default
+        );
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IPasswordService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IPasswordService.cs
@@ -19,5 +19,12 @@ namespace EcSiteBackend.Application.Common.Interfaces
         /// <param name="passwordHash"></param>
         /// <returns></returns>
         bool VerifyPassword(string password, string passwordHash);
+
+        /// <summary>
+        /// パスワード強度チェック
+        /// </summary>
+        /// <param name="password"></param>
+        /// <returns></returns>
+        bool IsPasswordStrong(string password);
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/InputOutputModels/ChangePasswordInput.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/InputOutputModels/ChangePasswordInput.cs
@@ -1,0 +1,38 @@
+namespace EcSiteBackend.Application.UseCases.InputOutputModels
+{
+    /// <summary>
+    /// パスワード変更時の入力モデル
+    /// </summary>
+    public class ChangePasswordInput
+    {
+        /// <summary>
+        /// ユーザーID
+        /// </summary>
+        public Guid UserId { get; set; } = Guid.Empty;
+
+        /// <summary>
+        /// 現在のパスワード（必須・8文字以上）
+        /// </summary>
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード（必須・8文字以上）
+        /// </summary>
+        public string NewPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード確認用（必須・8文字以上）
+        /// </summary>
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// IPアドレス
+        /// </summary>
+        public string? IpAddress { get; set; }
+
+        /// <summary>
+        /// ユーザーエージェント
+        /// </summary>
+        public string? UserAgent { get; set; }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/ChangePasswordInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/ChangePasswordInteractor.cs
@@ -132,7 +132,10 @@ namespace EcSiteBackend.Application.UseCases.Interactors
                         originalUser,
                         OperationType.Update,
                         input.UserId,
-                        cancellationToken);
+                        input.IpAddress,
+                        input.UserAgent,
+                        cancellationToken
+                        );
                 }
                 catch (Exception ex)
                 {

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/ChangePasswordInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/ChangePasswordInteractor.cs
@@ -1,0 +1,172 @@
+using EcSiteBackend.Application.Common.Constants;
+using EcSiteBackend.Application.Common.Exceptions;
+using EcSiteBackend.Application.Common.Interfaces;
+using EcSiteBackend.Application.Common.Interfaces.Repositories;
+using EcSiteBackend.Application.Common.Interfaces.Services;
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+using EcSiteBackend.Application.UseCases.Interfaces;
+using EcSiteBackend.Domain.Enums;
+using EcSiteBackend.Domain.Entities;
+using EcSiteBackend.Application.Common.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace EcSiteBackend.Application.UseCases.Interactors
+{
+    /// <summary>
+    /// パスワード変更ユースケースの実装
+    /// </summary>
+    public class ChangePasswordInteractor : IChangePasswordUseCase
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IHistoryService _historyService;
+        private readonly IPasswordService _passwordService;
+        private readonly IGenericRepository<LoginHistory> _loginHistoryRepository;
+        private readonly ITransactionService _transactionService;
+        private readonly IUserAgentParser _userAgentParser;
+        private readonly ILogger<ChangePasswordInteractor> _logger;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public ChangePasswordInteractor(
+            IUserRepository userRepository,
+            IHistoryService historyService,
+            IPasswordService passwordService,
+            IGenericRepository<LoginHistory> loginHistoryRepository,
+            ITransactionService transactionService,
+            IUserAgentParser userAgentParser,
+            ILogger<ChangePasswordInteractor> logger)
+        {
+            _userRepository = userRepository;
+            _historyService = historyService;
+            _passwordService = passwordService;
+            _loginHistoryRepository = loginHistoryRepository;
+            _transactionService = transactionService;
+            _userAgentParser = userAgentParser;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// パスワード変更を実行する
+        /// </summary>
+        public async Task ExecuteAsync(ChangePasswordInput input, CancellationToken cancellationToken)
+        {
+            await _transactionService.ExecuteAsync(async () =>
+            {
+                // 入力検証
+                ValidateInput(input);
+
+                // ユーザーの取得
+                var user = await _userRepository.GetByIdAsync(input.UserId, cancellationToken);
+                if (user == null || !user.IsActive)
+                {
+                    _logger.LogWarning("User not found or inactive: {UserId}", input.UserId);
+                    throw new NotFoundException(ErrorMessages.UserNotFound);
+                }
+
+                // 履歴保存用のクローンを作成
+                var originalUser = user.CloneForHistory();
+
+                // ログイン履歴エントリの準備
+                var loginHistory = new LoginHistory
+                {
+                    UserId = user.Id,
+                    Email = user.Email,
+                    AttemptedAt = DateTime.UtcNow,
+                    IsSuccess = false,
+                    FailureReason = ErrorCodes.InvalidPasswordReason,
+                    IpAddress = input.IpAddress,
+                    UserAgent = input.UserAgent,
+                    Browser = _userAgentParser.GetBrowser(input.UserAgent),
+                    DeviceInfo = _userAgentParser.GetDeviceInfo(input.UserAgent)
+                };
+
+                // 監査情報を設定
+                loginHistory.InitializeForCreate(user.Id);
+
+                try
+                {
+                    // 現在のパスワードの検証
+                    if (!_passwordService.VerifyPassword(input.CurrentPassword, user.PasswordHash))
+                    {
+                        loginHistory.FailureReason = "Invalid current password during password change";
+                        await _loginHistoryRepository.AddAsync(loginHistory, cancellationToken);
+                        await _loginHistoryRepository.SaveChangesAsync(cancellationToken);
+
+                        _logger.LogWarning("Invalid current password for user: {UserId}", input.UserId);
+                        throw new UnauthorizedException(ErrorMessages.InvalidCredentials);
+                    }
+
+                    // 新しいパスワードが現在のパスワードと同じでないか確認
+                    if (_passwordService.VerifyPassword(input.NewPassword, user.PasswordHash))
+                    {
+                        throw new ValidationException("NewPassword", ErrorMessages.SameAsCurrentPassword);
+                    }
+
+                    // パスワード強度の検証
+                    if (!_passwordService.IsPasswordStrong(input.NewPassword))
+                    {
+                        throw new ValidationException("NewPassword", ErrorMessages.WeakPassword);
+                    }
+
+                    // パスワードの更新
+                    var newPasswordHash = _passwordService.HashPassword(input.NewPassword);
+                    user.PasswordHash = newPasswordHash;
+                    user.MarkAsUpdated(user.Id); // 監査情報を設定
+
+                    _userRepository.Update(user);
+
+                    // 成功履歴の記録
+                    loginHistory.IsSuccess = true;
+                    loginHistory.FailureReason = null;
+                    await _loginHistoryRepository.AddAsync(loginHistory, cancellationToken);
+
+                    // 変更を保存
+                    await _userRepository.SaveChangesAsync(cancellationToken);
+                    await _loginHistoryRepository.SaveChangesAsync(cancellationToken);
+
+                    _logger.LogInformation("Password changed successfully for user: {UserId}", input.UserId);
+
+                    // 履歴を作成
+                    await _historyService.CreateUserHistoryAsync(
+                        originalUser,
+                        OperationType.Update,
+                        input.UserId,
+                        cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error changing password for user: {UserId}", input.UserId);
+                    throw;
+                }
+
+                return Task.CompletedTask;
+            }, cancellationToken);
+        }
+
+        /// <summary>
+        /// 入力値の検証
+        /// </summary>
+        /// <param name="input"></param>
+        /// <exception cref="ValidationException"></exception>
+        /// <exception cref="InvalidArgumentsException"></exception>
+        private void ValidateInput(ChangePasswordInput input)
+        {
+            if (input.NewPassword != input.ConfirmPassword)
+            {
+                throw new ValidationException("ConfirmPassword", ErrorMessages.PasswordMismatch);
+            }
+
+            if (string.IsNullOrWhiteSpace(input.CurrentPassword) ||
+                string.IsNullOrWhiteSpace(input.NewPassword))
+            {
+                throw new ValidationException("NewPassword", ErrorMessages.ValidationError);
+            }
+
+            if (input.UserId == Guid.Empty)
+            {
+                throw new InvalidArgumentsException("User ID", input.UserId);
+            }
+        }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/SignUpInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/SignUpInteractor.cs
@@ -124,7 +124,7 @@ namespace EcSiteBackend.Application.UseCases.Interactors
             }
 
             // パスワード強度チェック
-            if (input.Password.Length < 8)
+            if (!_passwordService.IsPasswordStrong(input.Password))
             {
                 throw new ValidationException("password", ErrorMessages.PasswordTooWeak);
             }

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/UpdateUserInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/UpdateUserInteractor.cs
@@ -84,6 +84,8 @@ namespace EcSiteBackend.Application.UseCases.Interactors
                     originalUser,
                     OperationType.Update,
                     input.Id,
+                    input.IpAddress,
+                    input.UserAgent,
                     cancellationToken);
             }, cancellationToken);
 

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interfaces/IChangePasswordUseCase.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interfaces/IChangePasswordUseCase.cs
@@ -1,0 +1,18 @@
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+
+namespace EcSiteBackend.Application.UseCases.Interfaces
+{
+    /// <summary>
+    /// パスワード変更ユースケース
+    /// </summary>
+    public interface IChangePasswordUseCase
+    {
+        /// <summary>
+        /// パスワードを変更する
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task ExecuteAsync(ChangePasswordInput passwordChangeInput, CancellationToken cancellationToken);
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/HistoryService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/HistoryService.cs
@@ -29,6 +29,8 @@ namespace EcSiteBackend.Infrastructure.Services
             User user,
             OperationType operationType,
             Guid operatedBy,
+            string? ipAddress = null,
+            string? userAgent = null,
             CancellationToken cancellationToken = default)
         {
             var history = _mapper.Map<UserHistory>(user);
@@ -37,6 +39,8 @@ namespace EcSiteBackend.Infrastructure.Services
             history.OperationType = operationType;
             history.OperatedBy = operatedBy;
             history.OperatedAt = DateTime.UtcNow;
+            history.IpAddress = ipAddress;
+            history.UserAgent = userAgent;
 
             await _userHistoryRepository.AddAsync(history, cancellationToken);
             await _userHistoryRepository.SaveChangesAsync(cancellationToken);

--- a/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/PasswordService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/PasswordService.cs
@@ -8,12 +8,23 @@ namespace EcSiteBackend.Infrastructure.Services
     /// </summary>
     public class PasswordService : IPasswordService
     {
+        /// <summary>
+        /// パスワードをハッシュ化
+        /// </summary>
+        /// <param name="password"></param>
+        /// <returns></returns>
         public string HashPassword(string password)
         {
             // BCryptでハッシュ化（ソルト自動生成）
             return BCrypt.Net.BCrypt.HashPassword(password);
         }
 
+        /// <summary>
+        /// パスワード検証
+        /// </summary>
+        /// <param name="password"></param>
+        /// <param name="passwordHash"></param>
+        /// <returns></returns>
         public bool VerifyPassword(string password, string passwordHash)
         {
             try
@@ -24,6 +35,33 @@ namespace EcSiteBackend.Infrastructure.Services
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// パスワードの強度を検証する
+        /// </summary>
+        /// <param name="password">検証するパスワード</param>
+        /// <returns>強度要件を満たす場合はtrue</returns>
+        public bool IsPasswordStrong(string password)
+        {
+            if (string.IsNullOrEmpty(password))
+                return false;
+
+            // 最小長のチェック
+            if (password.Length < 8)
+                return false;
+
+            // 大文字を含むか
+            bool hasUpperCase = password.Any(char.IsUpper);
+
+            // 小文字を含むか
+            bool hasLowerCase = password.Any(char.IsLower);
+
+            // 数字を含むか
+            bool hasDigit = password.Any(char.IsDigit);
+
+            // すべての要件を満たしているか確認
+            return hasUpperCase && hasLowerCase && hasDigit;
         }
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Inputs/ChangePasswordInputType.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Inputs/ChangePasswordInputType.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using EcSiteBackend.Application.Common.Attributes;
+
+namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Types.Inputs
+{
+    /// <summary>
+    /// パスワード変更の入力型
+    /// </summary>
+    public class ChangePasswordInputType
+    {
+        /// <summary>
+        /// 現在のパスワード（必須・8文字以上）
+        /// </summary>
+        [Required(ErrorMessage = "現在のパスワードは必須です")]
+        [MinLength(8, ErrorMessage = "現在のパスワードは8文字以上である必要があります")]
+        [Sensitive("現在のパスワードは機密情報です")]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード（必須・8文字以上）
+        /// </summary>
+        [Required(ErrorMessage = "新しいパスワードは必須です")]
+        [MinLength(8, ErrorMessage = "新しいパスワードは8文字以上である必要があります")]
+        [Sensitive("新しいパスワードは機密情報です")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード確認用（必須・8文字以上）
+        /// </summary>
+        [Required(ErrorMessage = "確認用のパスワードは必須です")]
+        [MinLength(8, ErrorMessage = "確認用のパスワードは8文字以上である必要があります")]
+        [Sensitive("確認用のパスワードは機密情報です")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Payloads/ChangePasswordPayload.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Payloads/ChangePasswordPayload.cs
@@ -1,0 +1,10 @@
+namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Types.Payloads
+{
+    /// <summary>
+    /// パスワード変更結果のペイロード
+    /// </summary>
+    public class ChangePasswordPayload : BasePayload
+    {
+        // 結果は成否のみ
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -89,6 +89,7 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
             services.AddScoped<ISignUpUseCase, SignUpInteractor>();
             services.AddScoped<ISignInUseCase, SignInInteractor>();
             services.AddScoped<IReadCurrentUserUseCase, ReadCurrentUserInteractor>();
+            services.AddScoped<IChangePasswordUseCase, ChangePasswordInteractor>();
             services.AddScoped<IUpdateUserUseCase, UpdateUserInteractor>();
 
             // 5. AutoMapper

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignUpInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignUpInteractorTests.cs
@@ -64,7 +64,7 @@ namespace EcSiteBackend.UnitTests.Interactors
             var input = new SignUpInput
             {
                 Email = "test@example.com",
-                Password = "SecurePassword123",
+                Password = "SecurePassword123huw3ga9wpjjg0wg4",
                 FirstName = "太郎",
                 LastName = "テスト",
                 PhoneNumber = "090-9999-9999",
@@ -135,6 +135,10 @@ namespace EcSiteBackend.UnitTests.Interactors
             _jwtServiceMock
                 .Setup(j => j.GenerateToken(It.IsAny<User>()))
                 .Returns(expectedToken);
+            
+            _passwordServiceMock
+                .Setup(s => s.IsPasswordStrong(It.IsAny<string>()))
+                .Returns(true);
 
             // Mapping
             _mapperMock

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignUpInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/SignUpInteractorTests.cs
@@ -135,7 +135,7 @@ namespace EcSiteBackend.UnitTests.Interactors
             _jwtServiceMock
                 .Setup(j => j.GenerateToken(It.IsAny<User>()))
                 .Returns(expectedToken);
-            
+
             _passwordServiceMock
                 .Setup(s => s.IsPasswordStrong(It.IsAny<string>()))
                 .Returns(true);
@@ -257,6 +257,7 @@ namespace EcSiteBackend.UnitTests.Interactors
             _mapperMock.Verify(m => m.Map<UserDto>(It.IsAny<User>()), Times.Once);
             _userAgentParserMock.Verify(p => p.GetBrowser(It.IsAny<string>()), Times.Once);
             _userAgentParserMock.Verify(p => p.GetDeviceInfo(It.IsAny<string>()), Times.Once);
+            _passwordServiceMock.Verify(p => p.IsPasswordStrong(It.IsAny<string>()), Times.Once);
         }
         
         [Fact(DisplayName = "異常系: メールアドレスが既に存在する場合、ConflictExceptionがスローされる")]

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -94,6 +94,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     It.IsAny<User>(),
                     It.IsAny<OperationType>(),
                     It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -126,6 +128,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
+                "1.11.1111",
+                "userAgent",
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -184,6 +188,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     It.IsAny<User>(),
                     It.IsAny<OperationType>(),
                     It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -216,6 +222,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
+                "1.12.12",
+                "useragent",
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -274,6 +282,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     It.IsAny<User>(),
                     It.IsAny<OperationType>(),
                     It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -307,6 +317,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
+                "1.12.1",
+                "userAgent",
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -367,6 +379,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     It.IsAny<User>(),
                     It.IsAny<OperationType>(),
                     It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -400,6 +414,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
+                "1.12.2",
+                "userAgent",
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -459,6 +475,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     It.IsAny<User>(),
                     It.IsAny<OperationType>(),
                     It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -492,6 +510,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
+                "1.23.45",
+                "userAgent",
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -537,6 +557,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     u.Email == "old.email@example.com"),
                 OperationType.Update,
                 userId,
+                "1.23.45",
+                "userAgent",
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -736,6 +758,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 It.IsAny<OperationType>(),
                 It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
                 It.IsAny<CancellationToken>()), Times.Never);
         }
 
@@ -773,6 +797,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     It.IsAny<User>(),
                     It.IsAny<OperationType>(),
                     It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception("History service error"));
 

--- a/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
+++ b/EcSiteBackend/tests/EcSiteBackend.UnitTests/Interactors/UpdateUserInteractorTests.cs
@@ -128,8 +128,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
-                "1.11.1111",
-                "userAgent",
+                null,
+                null,
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -222,8 +222,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
-                "1.12.12",
-                "useragent",
+                null,
+                null,
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -317,8 +317,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
-                "1.12.1",
-                "userAgent",
+                null,
+                null,
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -414,8 +414,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
-                "1.12.2",
-                "userAgent",
+                null,
+                null,
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -510,8 +510,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                 It.IsAny<User>(),
                 OperationType.Update,
                 userId,
-                "1.23.45",
-                "userAgent",
+                null,
+                null,
                 It.IsAny<CancellationToken>()), Times.Once);
             _mapperMock.Verify(mapper => mapper.Map<UserDto>(It.IsAny<User>()), Times.Once);
         }
@@ -557,8 +557,8 @@ namespace EcSiteBackend.UnitTests.Interactors
                     u.Email == "old.email@example.com"),
                 OperationType.Update,
                 userId,
-                "1.23.45",
-                "userAgent",
+                null,
+                null,
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 


### PR DESCRIPTION
### 概要
ログイン済みユーザーが現在のパスワードを入力して新しいパスワードに変更する機能を実装しました。

### 実装内容

#### GraphQL層
- **Mutation追加**: `changePassword` - 認証済みユーザーのパスワード変更
- **入力型**: `ChangePasswordInputType` - 現在のパスワード、新しいパスワード、確認用パスワード
- **出力型**: `ChangePasswordPayload` - 処理結果を返すペイロード

#### Application層
- **ユースケース**: `IChangePasswordUseCase` / `ChangePasswordInteractor`
  - 現在のパスワードの検証
  - パスワード強度チェック
  - 新旧パスワードの重複チェック
- **入力モデル**: `ChangePasswordInput` - IPアドレス、UserAgent情報を含む
- **パスワード強度検証**: `IPasswordService.IsPasswordStrong()` メソッドを追加

#### その他の変更
- **履歴管理**: `IHistoryService` にIPアドレスとUserAgentパラメータを追加
- **エラーメッセージ**: パスワード変更関連のエラーコード・メッセージを追加
- **ログイン履歴**: パスワード変更の成功/失敗を記録

### セキュリティ考慮事項
- ✅ 現在のパスワードの検証を必須化
- ✅ パスワード強度の検証（8文字以上、大文字・小文字・数字を含む）

### 動作確認
```graphql
mutation {
  changePassword(input: {
    currentPassword: "OldPassword123"
    newPassword: "NewPassword456"
    confirmPassword: "NewPassword456"
  }) {
    success
    errors {
      code
      message
    }
  }
}
```

### 今後の実装予定
- パスワードリセット機能（メール認証）
- パスワード変更通知メールの送信

### チェックリスト
- [x] ユニットテストの追加
- [x] 統合テストの追加
- [x] GraphQL Playgroundでの動作確認
- [x] エラーケースの確認（誤ったパスワード、弱いパスワード等）
- [x] ログイン履歴への記録確認
- [x] ユーザー変更履歴への記録確認

### 関連Issue
- #51 