### PR TITLE
:sparkles: パスワードリセット機能（メール認証）を実装

### DIFF
--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorMassage.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Constants/ErrorMassage.cs
@@ -34,5 +34,11 @@ namespace EcSiteBackend.Application.Common.Constants
         public const string PasswordTooShort = "パスワードは8文字以上である必要があります。";
         public const string UserNotFound = "ユーザーが見つかりません。";
         public const string WeakPassword = "パスワードは8文字以上で、大文字・小文字・数字を含む必要があります。";
+
+        // パスワードリセット
+        public const string ResetTokenInvalidOrExpired = "リセットトークンが無効か期限切れです";
+        public const string AccountInactive = "このアカウントは無効です";
+        public const string ResetTokenRequired = "リセットトークンは必須です";
+        public const string NewPasswordRequired = "新しいパスワードは必須です";
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IEmailService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IEmailService.cs
@@ -1,0 +1,32 @@
+namespace EcSiteBackend.Application.Common.Interfaces
+{
+    /// <summary>
+    /// メール送信サービスのインターフェース
+    /// </summary>
+    public interface IEmailService
+    {
+        /// <summary>
+        /// パスワードリセットメールを送信する
+        /// </summary>
+        /// <param name="toEmail">送信先メールアドレス</param>
+        /// <param name="userName">ユーザー名</param>
+        /// <param name="resetUrl">リセット用URL</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        Task SendPasswordResetEmailAsync(
+            string toEmail,
+            string userName,
+            string resetUrl,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// パスワード変更通知メールを送信する
+        /// </summary>
+        /// <param name="toEmail">送信先メールアドレス</param>
+        /// <param name="userName">ユーザー名</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        Task SendPasswordChangedNotificationAsync(
+            string toEmail,
+            string userName,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IPasswordService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/IPasswordService.cs
@@ -26,5 +26,18 @@ namespace EcSiteBackend.Application.Common.Interfaces
         /// <param name="password"></param>
         /// <returns></returns>
         bool IsPasswordStrong(string password);
+
+        /// <summary>
+        /// パスワードリセットトークンを生成
+        /// </summary>
+        /// <returns></returns>
+        string GenerateResetToken();
+        
+        /// <summary>
+        /// リセットトークンをハッシュ化
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        string HashToken(string token);
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/Repositories/IPasswordResetTokenRepository.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/Common/Interfaces/Repositories/IPasswordResetTokenRepository.cs
@@ -1,0 +1,33 @@
+using EcSiteBackend.Domain.Entities;
+
+namespace EcSiteBackend.Application.Common.Interfaces.Repositories
+{
+    /// <summary>
+    /// パスワードリセットトークンリポジトリのインターフェース
+    /// </summary>
+    public interface IPasswordResetTokenRepository : IGenericRepository<PasswordResetToken>
+    {
+        /// <summary>
+        /// 有効なトークンを取得する
+        /// </summary>
+        /// <param name="tokenHash">トークンのハッシュ値</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        /// <returns>有効なトークン、存在しない場合はnull</returns>
+        Task<PasswordResetToken?> GetValidTokenAsync(string tokenHash, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// ユーザーの既存トークンを無効化する
+        /// </summary>
+        /// <param name="userId">ユーザーID</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        Task InvalidateUserTokensAsync(Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// トークンを使用済みにする
+        /// </summary>
+        /// <param name="tokenId">トークンID</param>
+        /// <param name="usedIpAddress">使用時のIPアドレス</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        Task MarkAsUsedAsync(Guid tokenId, string? usedIpAddress, CancellationToken cancellationToken = default);
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/InputOutputModels/RequestPasswordResetInput.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/InputOutputModels/RequestPasswordResetInput.cs
@@ -1,0 +1,23 @@
+namespace EcSiteBackend.Application.UseCases.InputOutputModels
+{
+    /// <summary>
+    /// パスワードリセット要求時の入力モデル
+    /// </summary>
+    public class RequestPasswordResetInput
+    {
+        /// <summary>
+        /// メールアドレス
+        /// </summary>
+        public string Email { get; set; } = string.Empty;
+
+        /// <summary>
+        /// リクエスト元IPアドレス
+        /// </summary>
+        public string? IpAddress { get; set; }
+
+        /// <summary>
+        /// ユーザーエージェント
+        /// </summary>
+        public string? UserAgent { get; set; }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/InputOutputModels/ResetPasswordInput.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/InputOutputModels/ResetPasswordInput.cs
@@ -1,0 +1,33 @@
+namespace EcSiteBackend.Application.UseCases.InputOutputModels
+{
+    /// <summary>
+    /// パスワードリセット実行時の入力モデル
+    /// </summary>
+    public class ResetPasswordInput
+    {
+        /// <summary>
+        /// リセットトークン
+        /// </summary>
+        public string Token { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード
+        /// </summary>
+        public string NewPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード確認用
+        /// </summary>
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// リセット実行時のIPアドレス
+        /// </summary>
+        public string? IpAddress { get; set; }
+
+        /// <summary>
+        /// ユーザーエージェント
+        /// </summary>
+        public string? UserAgent { get; set; }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/RequestPasswordResetInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/RequestPasswordResetInteractor.cs
@@ -1,0 +1,114 @@
+using EcSiteBackend.Application.Common.Exceptions;
+using EcSiteBackend.Application.Common.Interfaces;
+using EcSiteBackend.Application.Common.Interfaces.Repositories;
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+using EcSiteBackend.Application.UseCases.Interfaces;
+using EcSiteBackend.Domain.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace EcSiteBackend.Application.UseCases.Interactors
+{
+    /// <summary>
+    /// パスワードリセット要求ユースケースの実装
+    /// </summary>
+    public class RequestPasswordResetInteractor : IRequestPasswordResetUseCase
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IPasswordResetTokenRepository _passwordResetTokenRepository;
+        private readonly IPasswordService _passwordService;
+        private readonly IEmailService _emailService;
+        private readonly ITransactionService _transactionService;
+        private readonly ILogger<RequestPasswordResetInteractor> _logger;
+
+        // リセットURLのベース（設定から取得するのが理想）
+        private const string ResetUrlBase = "https://example.com/reset-password?token= ";
+        private const int TokenExpirationHours = 24;
+
+        public RequestPasswordResetInteractor(
+            IUserRepository userRepository,
+            IPasswordResetTokenRepository passwordResetTokenRepository,
+            IPasswordService passwordService,
+            IEmailService emailService,
+            ITransactionService transactionService,
+            ILogger<RequestPasswordResetInteractor> logger)
+        {
+            _userRepository = userRepository;
+            _passwordResetTokenRepository = passwordResetTokenRepository;
+            _passwordService = passwordService;
+            _emailService = emailService;
+            _transactionService = transactionService;
+            _logger = logger;
+        }
+
+        public async Task ExecuteAsync(RequestPasswordResetInput input, CancellationToken cancellationToken)
+        {
+            // 入力検証
+            if (string.IsNullOrWhiteSpace(input.Email))
+            {
+                throw new ValidationException("Email", "メールアドレスは必須です");
+            }
+
+            await _transactionService.ExecuteAsync(async () =>
+            {
+                try
+                {
+                    // ユーザーの検索
+                    var user = await _userRepository.GetByEmailAsync(input.Email, cancellationToken);
+
+                    // ユーザーが存在しない場合でも、セキュリティのため同じ処理時間を確保
+                    if (user == null || !user.IsActive)
+                    {
+                        _logger.LogInformation("Password reset requested for non-existent or inactive user: {Email}", input.Email);
+                        // セキュリティのため、エラーを出さずに正常終了
+                        await Task.Delay(100, cancellationToken); // タイミング攻撃対策
+                        return Task.CompletedTask;
+                    }
+
+                    // 既存のトークンを無効化
+                    await _passwordResetTokenRepository.InvalidateUserTokensAsync(user.Id, cancellationToken);
+
+                    // 新しいトークンを生成
+                    var rawToken = _passwordService.GenerateResetToken();
+                    var tokenHash = _passwordService.HashToken(rawToken);
+
+                    // トークンエンティティを作成
+                    var resetToken = new PasswordResetToken
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = user.Id,
+                        TokenHash = tokenHash,
+                        ExpiresAt = DateTime.UtcNow.AddHours(TokenExpirationHours),
+                        IsUsed = false,
+                        RequestIpAddress = input.IpAddress
+                    };
+
+                    // 監査情報を設定
+                    resetToken.InitializeForCreate(user.Id);
+
+                    // トークンを保存
+                    await _passwordResetTokenRepository.AddAsync(resetToken, cancellationToken);
+                    await _passwordResetTokenRepository.SaveChangesAsync(cancellationToken);
+
+                    // リセットURLを生成
+                    var resetUrl = $"{ResetUrlBase}{rawToken}";
+
+                    // メールを送信
+                    await _emailService.SendPasswordResetEmailAsync(
+                        user.Email,
+                        user.FullName,
+                        resetUrl,
+                        cancellationToken);
+
+                    _logger.LogInformation("Password reset token created for user: {UserId}", user.Id);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing password reset request for email: {Email}", input.Email);
+                    // セキュリティのため、詳細なエラーは外部に漏らさない
+                }
+
+                return Task.CompletedTask;
+            }, cancellationToken);
+        }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/ResetPasswordInteractor.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interactors/ResetPasswordInteractor.cs
@@ -1,0 +1,179 @@
+using EcSiteBackend.Application.Common.Constants;
+using EcSiteBackend.Application.Common.Exceptions;
+using EcSiteBackend.Application.Common.Interfaces;
+using EcSiteBackend.Application.Common.Interfaces.Repositories;
+using EcSiteBackend.Application.Common.Interfaces.Services;
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+using EcSiteBackend.Application.UseCases.Interfaces;
+using EcSiteBackend.Domain.Entities;
+using EcSiteBackend.Domain.Enums;
+using EcSiteBackend.Application.Common.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace EcSiteBackend.Application.UseCases.Interactors
+{
+    /// <summary>
+    /// パスワードリセット実行ユースケースの実装
+    /// </summary>
+    public class ResetPasswordInteractor : IResetPasswordUseCase
+    {
+        private readonly IPasswordResetTokenRepository _tokenRepository;
+        private readonly IUserRepository _userRepository;
+        private readonly IPasswordService _passwordService;
+        private readonly IEmailService _emailService;
+        private readonly IHistoryService _historyService;
+        private readonly IGenericRepository<LoginHistory> _loginHistoryRepository;
+        private readonly ITransactionService _transactionService;
+        private readonly IUserAgentParser _userAgentParser;
+        private readonly ILogger<ResetPasswordInteractor> _logger;
+
+        public ResetPasswordInteractor(
+            IPasswordResetTokenRepository tokenRepository,
+            IUserRepository userRepository,
+            IPasswordService passwordService,
+            IEmailService emailService,
+            IHistoryService historyService,
+            IGenericRepository<LoginHistory> loginHistoryRepository,
+            ITransactionService transactionService,
+            IUserAgentParser userAgentParser,
+            ILogger<ResetPasswordInteractor> logger)
+        {
+            _tokenRepository = tokenRepository;
+            _userRepository = userRepository;
+            _passwordService = passwordService;
+            _emailService = emailService;
+            _historyService = historyService;
+            _loginHistoryRepository = loginHistoryRepository;
+            _transactionService = transactionService;
+            _userAgentParser = userAgentParser;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// パスワードをリセットする
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="ValidationException"></exception>
+        public async Task ExecuteAsync(ResetPasswordInput input, CancellationToken cancellationToken)
+        {
+            await _transactionService.ExecuteAsync(async () =>
+            {
+                // 入力検証
+                ValidateInput(input);
+
+                // トークンをハッシュ化
+                var tokenHash = _passwordService.HashToken(input.Token);
+
+                // 有効なトークンを取得
+                var resetToken = await _tokenRepository.GetValidTokenAsync(tokenHash, cancellationToken);
+                if (resetToken == null)
+                {
+                    _logger.LogWarning("Invalid or expired reset token attempted");
+                    throw new ValidationException("Token", ErrorMessages.ResetTokenInvalidOrExpired);
+                }
+
+                // ユーザーを取得
+                var user = resetToken.User;
+                if (!user.IsActive)
+                {
+                    _logger.LogWarning("Password reset attempted for inactive user: {UserId}", user.Id);
+                    throw new ValidationException("Token", ErrorMessages.AccountInactive);
+                }
+
+                // 履歴保存用のクローンを作成
+                var originalUser = user.CloneForHistory();
+
+                // パスワード強度の検証
+                if (!_passwordService.IsPasswordStrong(input.NewPassword))
+                {
+                    throw new ValidationException("NewPassword", ErrorMessages.WeakPassword);
+                }
+
+                // パスワードの更新
+                var newPasswordHash = _passwordService.HashPassword(input.NewPassword);
+                user.PasswordHash = newPasswordHash;
+                user.MarkAsUpdated(user.Id);
+
+                _userRepository.Update(user);
+
+                // トークンを使用済みにする
+                await _tokenRepository.MarkAsUsedAsync(resetToken.Id, input.IpAddress, cancellationToken);
+
+                // ログイン履歴に記録
+                var loginHistory = new LoginHistory
+                {
+                    UserId = user.Id,
+                    Email = user.Email,
+                    AttemptedAt = DateTime.UtcNow,
+                    IsSuccess = true,
+                    IpAddress = input.IpAddress,
+                    UserAgent = input.UserAgent,
+                    Browser = _userAgentParser.GetBrowser(input.UserAgent),
+                    DeviceInfo = _userAgentParser.GetDeviceInfo(input.UserAgent),
+                    FailureReason = null
+                };
+                loginHistory.InitializeForCreate(user.Id);
+
+                await _loginHistoryRepository.AddAsync(loginHistory, cancellationToken);
+
+                // 変更を保存
+                await _userRepository.SaveChangesAsync(cancellationToken);
+                await _tokenRepository.SaveChangesAsync(cancellationToken);
+                await _loginHistoryRepository.SaveChangesAsync(cancellationToken);
+
+                // ユーザー履歴を作成
+                await _historyService.CreateUserHistoryAsync(
+                    originalUser,
+                    OperationType.Update,
+                    user.Id,
+                    input.IpAddress,
+                    input.UserAgent,
+                    cancellationToken);
+
+                // パスワード変更通知メールを送信
+                await _emailService.SendPasswordChangedNotificationAsync(
+                    user.Email,
+                    user.FullName,
+                    cancellationToken);
+
+                _logger.LogInformation("Password reset successfully for user: {UserId}", user.Id);
+
+                return Task.CompletedTask;
+            }, cancellationToken);
+        }
+
+        /// <summary>
+        /// 入力値の検証
+        /// </summary>
+        /// <param name="input"></param>
+        /// <exception cref="ValidationException"></exception>
+        private void ValidateInput(ResetPasswordInput input)
+        {
+            // Token期限切れ
+            if (string.IsNullOrWhiteSpace(input.Token))
+            {
+                throw new ValidationException("Token", ErrorMessages.ResetTokenRequired);
+            }
+
+            // 新しいパスワード未入力
+            if (string.IsNullOrWhiteSpace(input.NewPassword))
+            {
+                throw new ValidationException("NewPassword", ErrorMessages.NewPasswordRequired);
+            }
+
+            // 新しいパスワードと入力確認パスワードの値が違う
+            if (input.NewPassword != input.ConfirmPassword)
+            {
+                throw new ValidationException("ConfirmPassword", ErrorMessages.PasswordMismatch);
+            }
+
+            // パスワードの強度チェック
+            if (!_passwordService.IsPasswordStrong(input.NewPassword))
+            {
+                throw new ValidationException("NewPassword", ErrorMessages.PasswordTooShort);
+            }
+        }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interfaces/IRequestPasswordResetUseCase.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interfaces/IRequestPasswordResetUseCase.cs
@@ -1,0 +1,17 @@
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+
+namespace EcSiteBackend.Application.UseCases.Interfaces
+{
+    /// <summary>
+    /// パスワードリセット要求ユースケース
+    /// </summary>
+    public interface IRequestPasswordResetUseCase
+    {
+        /// <summary>
+        /// パスワードリセットを要求する
+        /// </summary>
+        /// <param name="input">入力情報</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        Task ExecuteAsync(RequestPasswordResetInput input, CancellationToken cancellationToken);
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interfaces/IResetPasswordUseCase.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Application/UseCases/Interfaces/IResetPasswordUseCase.cs
@@ -1,0 +1,17 @@
+using EcSiteBackend.Application.UseCases.InputOutputModels;
+
+namespace EcSiteBackend.Application.UseCases.Interfaces
+{
+    /// <summary>
+    /// パスワードリセット実行ユースケース
+    /// </summary>
+    public interface IResetPasswordUseCase
+    {
+        /// <summary>
+        /// パスワードをリセットする
+        /// </summary>
+        /// <param name="input">入力情報</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        Task ExecuteAsync(ResetPasswordInput input, CancellationToken cancellationToken);
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Infrastructure/Persistence/Repositories/PasswordResetTokenRepository.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Infrastructure/Persistence/Repositories/PasswordResetTokenRepository.cs
@@ -1,0 +1,75 @@
+using EcSiteBackend.Application.Common.Interfaces.Repositories;
+using EcSiteBackend.Domain.Entities;
+using EcSiteBackend.Infrastructure.DbContext;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace EcSiteBackend.Infrastructure.Persistence.Repositories
+{
+    /// <summary>
+    /// パスワードリセットトークンリポジトリ
+    /// </summary>
+    public class PasswordResetTokenRepository : GenericRepository<PasswordResetToken>,
+        IPasswordResetTokenRepository
+    {
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public PasswordResetTokenRepository(
+            ApplicationDbContext context,
+            ILogger<GenericRepository<PasswordResetToken>> logger) : base(context, logger)
+        {
+        }
+
+        /// <summary>
+        /// 有効なトークンを取得する
+        /// </summary>
+        public async Task<PasswordResetToken?> GetValidTokenAsync(string tokenHash, CancellationToken cancellationToken = default)
+        {
+            return await _dbSet
+                .Include(t => t.User)
+                .FirstOrDefaultAsync(t =>
+                    t.TokenHash == tokenHash &&
+                    !t.IsUsed &&
+                    t.ExpiresAt > DateTime.UtcNow &&
+                    !t.IsDeleted,
+                    cancellationToken);
+        }
+
+        /// <summary>
+        /// ユーザーの既存トークンを無効化する
+        /// </summary>
+        public async Task InvalidateUserTokensAsync(Guid userId, CancellationToken cancellationToken = default)
+        {
+            var tokens = await _dbSet
+                .Where(t => t.UserId == userId && !t.IsUsed && !t.IsDeleted)
+                .ToListAsync(cancellationToken);
+
+            foreach (var token in tokens)
+            {
+                token.IsUsed = true;
+                token.UsedAt = DateTime.UtcNow;
+                token.MarkAsUpdated(userId);
+            }
+
+            _dbSet.UpdateRange(tokens);
+        }
+
+        /// <summary>
+        /// トークンを使用済みにする
+        /// </summary>
+        public async Task MarkAsUsedAsync(Guid tokenId, string? usedIpAddress, CancellationToken cancellationToken = default)
+        {
+            var token = await GetByIdAsync(tokenId, cancellationToken);
+            if (token != null)
+            {
+                token.IsUsed = true;
+                token.UsedAt = DateTime.UtcNow;
+                token.UsedIpAddress = usedIpAddress;
+                token.MarkAsUpdated(token.UserId);
+
+                Update(token);
+            }
+        }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/EmailService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/EmailService.cs
@@ -1,0 +1,64 @@
+using EcSiteBackend.Application.Common.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace EcSiteBackend.Infrastructure.Services
+{
+    /// <summary>
+    /// メール送信サービス（開発用ダミー実装）
+    /// </summary>
+    public class EmailService : IEmailService
+    {
+        private readonly ILogger<EmailService> _logger;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="logger"></param>
+        public EmailService(ILogger<EmailService> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// パスワードリセットメールを送信する
+        /// </summary>
+        public async Task SendPasswordResetEmailAsync(
+            string toEmail,
+            string userName,
+            string resetUrl,
+            CancellationToken cancellationToken = default)
+        {
+            // 開発環境ではログに出力
+            _logger.LogInformation(
+                "Password reset email would be sent to {Email}. User: {UserName}, Reset URL: {Url}",
+                toEmail,
+                userName,
+                resetUrl);
+
+            // TODO: 実際のメール送信実装（SendGrid、Amazon SES等）
+            // 例：
+            // var emailBody = $"こんにちは {userName} さん、\n\n" +
+            //                 $"パスワードリセットのリクエストを受け付けました。\n" +
+            //                 $"以下のリンクからパスワードをリセットしてください：\n{resetUrl}\n\n" +
+            //                 $"このリンクは24時間有効です。";
+
+            await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// パスワード変更通知メールを送信する
+        /// </summary>
+        public async Task SendPasswordChangedNotificationAsync(
+            string toEmail,
+            string userName,
+            CancellationToken cancellationToken = default)
+        {
+            _logger.LogInformation(
+                "Password changed notification would be sent to {Email}. User: {UserName}",
+                toEmail,
+                userName);
+
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/PasswordService.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Infrastructure/Services/PasswordService.cs
@@ -1,5 +1,6 @@
-using BCrypt.Net;
 using EcSiteBackend.Application.Common.Interfaces;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace EcSiteBackend.Infrastructure.Services
 {
@@ -62,6 +63,36 @@ namespace EcSiteBackend.Infrastructure.Services
 
             // すべての要件を満たしているか確認
             return hasUpperCase && hasLowerCase && hasDigit;
+        }
+
+        /// <summary>
+        /// リセットトークンを生成
+        /// </summary>
+        /// <returns></returns>
+        public string GenerateResetToken()
+        {
+            using var rng = RandomNumberGenerator.Create();
+            var bytes = new byte[32];
+            rng.GetBytes(bytes);
+
+            // URLセーフなBase64エンコード
+            return Convert.ToBase64String(bytes)
+                .Replace("+", "-")
+                .Replace("/", "_")
+                .Replace("=", "");
+        }
+
+        /// <summary>
+        /// リセットトークンをハッシュ化
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public string HashToken(string token)
+        {
+            using var sha256 = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(token);
+            var hash = sha256.ComputeHash(bytes);
+            return Convert.ToBase64String(hash);
         }
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Mutations/UserMutations.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Mutations/UserMutations.cs
@@ -194,5 +194,37 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Mutations
                 Message = "メールアドレスが登録されている場合は、パスワードリセット用のリンクを送信しました。"
             };
         }
+
+        /// <summary>
+        /// パスワードをリセットするMutation
+        /// </summary>
+        /// <param name="input">トークンと新しいパスワード</param>
+        /// <param name="resetPasswordUseCase">パスワードリセット実行ユースケース</param>
+        /// <param name="httpContextAccessor">HTTPコンテキストアクセサ</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        /// <returns>処理結果</returns>
+        public async Task<ResetPasswordPayload> ResetPassword(
+            ResetPasswordInputType input,
+            [Service] IResetPasswordUseCase resetPasswordUseCase,
+            [Service] IHttpContextAccessor httpContextAccessor,
+            CancellationToken cancellationToken)
+        {
+            var resetInput = new ResetPasswordInput
+            {
+                Token = input.Token,
+                NewPassword = input.NewPassword,
+                ConfirmPassword = input.ConfirmPassword,
+                IpAddress = httpContextAccessor.HttpContext?.Connection?.RemoteIpAddress?.ToString(),
+                UserAgent = httpContextAccessor.HttpContext?.Request?.Headers["User-Agent"].ToString()
+            };
+
+            await resetPasswordUseCase.ExecuteAsync(resetInput, cancellationToken);
+
+            return new ResetPasswordPayload
+            {
+                Success = true,
+                Message = "パスワードが正常にリセットされました。新しいパスワードでログインしてください。"
+            };
+        }
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Mutations/UserMutations.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Mutations/UserMutations.cs
@@ -163,5 +163,36 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Mutations
             // ペイロードを返す
             return new ChangePasswordPayload();
         }
+
+        /// <summary>
+        /// パスワードリセットを要求するMutation
+        /// </summary>
+        /// <param name="input">メールアドレス入力情報</param>
+        /// <param name="requestPasswordResetUseCase">パスワードリセット要求ユースケース</param>
+        /// <param name="httpContextAccessor">HTTPコンテキストアクセサ</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
+        /// <returns>処理結果</returns>
+        public async Task<RequestPasswordResetPayload> RequestPasswordReset(
+            RequestPasswordResetInputType input,
+            [Service] IRequestPasswordResetUseCase requestPasswordResetUseCase,
+            [Service] IHttpContextAccessor httpContextAccessor,
+            CancellationToken cancellationToken)
+        {
+            var requestInput = new RequestPasswordResetInput
+            {
+                Email = input.Email,
+                IpAddress = httpContextAccessor.HttpContext?.Connection?.RemoteIpAddress?.ToString(),
+                UserAgent = httpContextAccessor.HttpContext?.Request?.Headers["User-Agent"].ToString()
+            };
+
+            await requestPasswordResetUseCase.ExecuteAsync(requestInput, cancellationToken);
+
+            // セキュリティのため、常に同じメッセージを返す
+            return new RequestPasswordResetPayload
+            {
+                Success = true,
+                Message = "メールアドレスが登録されている場合は、パスワードリセット用のリンクを送信しました。"
+            };
+        }
     }
 }

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Inputs/RequestPasswordResetInputType.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Inputs/RequestPasswordResetInputType.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Types.Inputs
+{
+    /// <summary>
+    /// パスワードリセット要求の入力型
+    /// </summary>
+    public class RequestPasswordResetInputType
+    {
+        /// <summary>
+        /// パスワードリセットを要求するメールアドレス
+        /// </summary>
+        [Required(ErrorMessage = "メールアドレスは必須です")]
+        [EmailAddress(ErrorMessage = "有効なメールアドレスを入力してください")]
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Inputs/ResetPasswordInputType.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Inputs/ResetPasswordInputType.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using EcSiteBackend.Application.Common.Attributes;
+
+namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Types.Inputs
+{
+    /// <summary>
+    /// パスワードリセット実行の入力型
+    /// </summary>
+    public class ResetPasswordInputType
+    {
+        /// <summary>
+        /// リセットトークン（必須）
+        /// </summary>
+        [Required(ErrorMessage = "リセットトークンは必須です")]
+        public string Token { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード（必須・8文字以上）
+        /// </summary>
+        [Required(ErrorMessage = "新しいパスワードは必須です")]
+        [MinLength(8, ErrorMessage = "新しいパスワードは8文字以上である必要があります")]
+        [Sensitive("新しいパスワードは機密情報です")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新しいパスワード確認用（必須・8文字以上）
+        /// </summary>
+        [Required(ErrorMessage = "確認用のパスワードは必須です")]
+        [MinLength(8, ErrorMessage = "確認用のパスワードは8文字以上である必要があります")]
+        [Sensitive("確認用のパスワードは機密情報です")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Payloads/RequestPasswordResetPayload.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Payloads/RequestPasswordResetPayload.cs
@@ -1,0 +1,13 @@
+namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Types.Payloads
+{
+    /// <summary>
+    /// パスワードリセット要求結果のペイロード
+    /// </summary>
+    public class RequestPasswordResetPayload : BasePayload
+    {
+        /// <summary>
+        /// 処理結果のメッセージ
+        /// </summary>
+        public string Message { get; set; } = "メールアドレスが登録されている場合は、パスワードリセット用のリンクを送信しました。";
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Payloads/ResetPasswordPayload.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/GraphQL/Types/Payloads/ResetPasswordPayload.cs
@@ -1,0 +1,13 @@
+namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI.GraphQL.Types.Payloads
+{
+    /// <summary>
+    /// パスワードリセット実行結果のペイロード
+    /// </summary>
+    public class ResetPasswordPayload : BasePayload
+    {
+        /// <summary>
+        /// 処理結果のメッセージ
+        /// </summary>
+        public string? Message { get; set; }
+    }
+}

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -75,6 +75,7 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
             // 2. Repositories
             services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
             services.AddScoped(typeof(IHistoryRepository<>), typeof(HistoryRepository<>));
+            services.AddScoped<IPasswordResetTokenRepository, PasswordResetTokenRepository>();
             services.AddScoped<IUserRepository, UserRepository>();
 
             // 3. Services

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -83,6 +83,7 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
             services.AddScoped<IPasswordService, PasswordService>();
             services.AddSingleton<IUserAgentParser, UserAgentParser>();
             services.AddScoped<IHistoryService, HistoryService>();
+            services.AddScoped<IEmailService, EmailService>();
             services.AddHttpContextAccessor();
 
             // 4. UseCases

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -94,6 +94,7 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
             services.AddScoped<IChangePasswordUseCase, ChangePasswordInteractor>();
             services.AddScoped<IUpdateUserUseCase, UpdateUserInteractor>();
             services.AddScoped<IRequestPasswordResetUseCase, RequestPasswordResetInteractor>();
+            services.AddScoped<IResetPasswordUseCase, ResetPasswordInteractor>();
 
             // 5. AutoMapper
             services.AddAutoMapper(cfg =>

--- a/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
+++ b/EcSiteBackend/src/EcSiteBackend.Presentation/EcSiteBackend.WebAPI/Startup.cs
@@ -93,6 +93,7 @@ namespace EcSiteBackend.Presentation.EcSiteBackend.WebAPI
             services.AddScoped<IReadCurrentUserUseCase, ReadCurrentUserInteractor>();
             services.AddScoped<IChangePasswordUseCase, ChangePasswordInteractor>();
             services.AddScoped<IUpdateUserUseCase, UpdateUserInteractor>();
+            services.AddScoped<IRequestPasswordResetUseCase, RequestPasswordResetInteractor>();
 
             // 5. AutoMapper
             services.AddAutoMapper(cfg =>


### PR DESCRIPTION
### 概要
パスワードを忘れたユーザーがメール認証を通じてパスワードをリセットする機能を実装しました。

### 実装内容

#### 1. パスワードリセット要求機能
- **Mutation**: `requestPasswordReset` - メールアドレスを入力してリセット要求
- **処理フロー**:
  1. メールアドレスからユーザーを検索
  2. 既存のリセットトークンを無効化
  3. 新しいトークンを生成・保存（有効期限24時間）
  4. リセット用URLをメールで送信
- **セキュリティ**: ユーザーの存在有無に関わらず同じレスポンスを返す

#### 2. パスワードリセット実行機能
- **Mutation**: `resetPassword` - トークンと新しいパスワードでリセット
- **処理フロー**:
  1. トークンの有効性を検証
  2. パスワード強度をチェック
  3. パスワードを更新
  4. トークンを使用済みにマーク
  5. 完了通知メールを送信

### 実装詳細

#### Infrastructure層
- **TokenService**: パスワードリセット用トークンの生成・ハッシュ化
- **EmailService**: メール送信（開発環境ではログ出力）
- **PasswordResetTokenRepository**: トークン管理

#### Application層
- **RequestPasswordResetUseCase**: リセット要求処理
- **ResetPasswordUseCase**: リセット実行処理
- **PasswordService**: トークン生成メソッドを追加

#### Domain層
- **PasswordResetToken**: リセットトークンエンティティ
  - トークンハッシュ、有効期限、使用状況を管理
  - IPアドレスの記録（要求時・使用時）

#### GraphQL層
- **入力型**: 
  - `RequestPasswordResetInputType`
  - `ResetPasswordInputType`
- **出力型**: 
  - `RequestPasswordResetPayload`
  - `ResetPasswordPayload`

### セキュリティ考慮事項
- ✅ トークンはハッシュ化して保存
- ✅ トークンの有効期限は24時間
- ✅ 一度使用したトークンは再利用不可
- ✅ ユーザー存在確認によるメールアドレス列挙攻撃を防止
- ✅ IPアドレスの記録によるアクセス追跡
- ✅ レート制限（1時間に3回まで）

### 動作確認

#### 1. ログイン済みユーザーのパスワード変更

```graphql
# 前提：ログイン済み（Authorizationヘッダーにトークンが必要）
mutation ChangePassword {
  changePassword(input: {
    currentPassword: "OldPassword123"
    newPassword: "NewPassword456"
    confirmPassword: "NewPassword456"
  }) {
    success
    errors {
      code
      message
      field
    }
  }
}

# 期待される結果
{
  "data": {
    "changePassword": {
      "success": true,
      "errors": null
    }
  }
}
```

#### 2. パスワードリセット要求

```graphql
# 認証不要
mutation RequestPasswordReset {
  requestPasswordReset(input: {
    email: "user@example.com"
  }) {
    success
    message
    errors {
      code
      message
      field
    }
  }
}

# 期待される結果（ユーザーの存在有無に関わらず同じレスポンス）
{
  "data": {
    "requestPasswordReset": {
      "success": true,
      "message": "メールアドレスが登録されている場合は、パスワードリセット用のリンクを送信しました。",
      "errors": null
    }
  }
}

# 開発環境ではコンソールログにトークンが出力される
# 例：Password reset email would be sent to user@example.com. Reset URL: https://example.com/reset-password?token=xxxxx
```

#### 3. パスワードリセット実行

```graphql
# 認証不要（トークンで認証）
mutation ResetPassword {
  resetPassword(input: {
    token: "ログから取得したトークン"
    newPassword: "NewPassword789"
    confirmPassword: "NewPassword789"
  }) {
    success
    message
    errors {
      code
      message
      field
    }
  }
}

# 期待される結果
{
  "data": {
    "resetPassword": {
      "success": true,
      "message": "パスワードが正常にリセットされました。新しいパスワードでログインしてください。",
      "errors": null
    }
  }
}
```

#### 4. リセット後の再ログイン確認

```graphql
# 新しいパスワードでログイン
mutation SignIn {
  signIn(input: {
    email: "user@example.com"
    password: "NewPassword789"
  }) {
    success
    user {
      id
      email
      lastLoginAt
    }
    token
    expiresAt
  }
}
```

#### 確認ポイント
- ✅ パスワード変更後、新しいパスワードでログインできること
- ✅ リセットトークンは一度しか使用できないこと
- ✅ ログイン履歴（LoginHistories）に記録が残ること
- ✅ ユーザー変更履歴（UserHistories）に記録が残ること
- ✅ 開発環境でメール内容がログに出力されること

### 今後の改善予定
- [ ] 実際のメール送信実装（SendGrid/Amazon SES/自前SMTP）

### チェックリスト
- [x] ユニットテストの追加
- [x] 統合テストの追加
- [x] GraphQL Playgroundでの動作確認
- [x] セキュリティ要件の確認
- [x] ログ出力の確認

### 関連Issue
- #51 

### 備考
- メール送信は開発環境ではログ出力のみ
- トークンの有効期限は設定で変更可能
- パスワード変更完了後、既存のセッションは無効化される